### PR TITLE
Replace constructor value positions to make the overridable

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ const fetch = require('node-fetch')
 class NodejsProvider extends BrowserProvider {
   constructor (url, options = {}) {
     super(url, {
-      ...options,
       WebSocket,
-      fetch
+      fetch,
+      ...options
     })
   }
 }


### PR DESCRIPTION
## Changelog

- Replaced positions of values in constructor to make them overridable 

## Motivation

We were unable to override `node-fetch` with custom `fetch` function due to `options` object being spread before `fetch` function.