### PR TITLE
Revert "chore(deps): bump node-fetch from 2.6.7 to 3.2.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "(Apache-2.0 AND MIT)",
   "dependencies": {
     "@filecoin-shipyard/lotus-client-provider-browser": "^1.0.1",
-    "node-fetch": "^3.2.1",
+    "node-fetch": "^2.6.1",
     "ws": "^8.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts filecoin-shipyard/js-lotus-client-provider-nodejs#17